### PR TITLE
Adding EF to the project. 

### DIFF
--- a/persistence/ApplicationContext.cs
+++ b/persistence/ApplicationContext.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.EntityFrameworkCore;
+
+namespace av2_net.Persistence
+{
+  public class TempModel
+  {
+    public int Id { get; set; }
+    public string Name { get; set; }
+  }
+
+  public class ApplicationContext : DbContext
+  {
+    public DbSet<TempModel> TempModels { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlite("Filename=./app.db");
+    }
+  }
+}

--- a/project.json
+++ b/project.json
@@ -4,6 +4,11 @@
       "version": "1.0.0",
       "type": "platform"
     },
+    "Microsoft.EntityFrameworkCore.Sqlite": "1.0.0",
+    "Microsoft.EntityFrameworkCore.Design": {
+      "version": "1.0.0-preview2-final",
+      "type": "build"
+    },
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
@@ -14,6 +19,7 @@
     "Microsoft.Extensions.Configuration.CommandLine": "1.0.0"
   },
   "tools": {
+    "Microsoft.EntityFrameworkCore.Tools": "1.0.0-preview2-final",
     "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
   },
   "frameworks": {


### PR DESCRIPTION
Dependencies and tools added to the project.json file and was created a class named ApplicationContext to configure the EF, for example there is a TempModel in this file and a property declared in the ApplicationContext class. To generate a migration use the command 'dotnet ef migrations add MigrationName' and 'dotnet ef database update' to apply the migration.
